### PR TITLE
Add session data to the Player

### DIFF
--- a/apex_legends/base.py
+++ b/apex_legends/base.py
@@ -14,8 +14,8 @@ class ApexLegends:
     def __init__(self, api_key):
         self.client = Client(api_key)
 
-    def player(self, player=None, platform=Platform.PC):
-        endpoint = 'profile/%s/%s' % (platform.value, player)
+    def player(self, player_name=None, platform=Platform.PC):
+        endpoint = 'profile/%s/%s' % (platform.value, player_name)
         data = self.client.request(endpoint)
 
         ## Load the game session data

--- a/apex_legends/base.py
+++ b/apex_legends/base.py
@@ -17,8 +17,14 @@ class ApexLegends:
     def player(self, player=None, platform=Platform.PC):
         endpoint = 'profile/%s/%s' % (platform.value, player)
         data = self.client.request(endpoint)
+
+        ## Load the game session data
+        games_endpoint = endpoint + '/sessions'
+        sessions = self.client.request(games_endpoint)
         if data.get('data') and 'userInfo' in data.get('data'):
-            return Player(data)
+            player = Player(data)
+            player.set_sessions(session_data=sessions.get('data'))
+            return player
         raise UnknownPlayerError
 
 

--- a/apex_legends/domain.py
+++ b/apex_legends/domain.py
@@ -57,6 +57,11 @@ class Player(Domain):
             if segment['type'] == 'legend':
                 self.legends.append(Legend(segment))
 
+    def set_sessions(self, session_data):
+        self.sessions = []
+        for data in session_data['items']:
+            self.sessions.append(Session(data))
+
     def __str__(self):
         general_stats = {'level': 'Level',
            'kills': 'Total kills',
@@ -81,3 +86,14 @@ class Legend(Domain):
         for stat, value in self._stats.items():
             setattr(self, stat.lower(),
                     value['value'])
+
+
+class Session(Domain):
+
+    def from_json(self):
+        super().from_json()
+        self._stats = self._data.get('stats')
+        for stat, value in self._stats.items():
+            setattr(self, stat.lower(),
+                    value['value'])
+

--- a/apex_legends/domain.py
+++ b/apex_legends/domain.py
@@ -96,4 +96,3 @@ class Session(Domain):
         for stat, value in self._stats.items():
             setattr(self, stat.lower(),
                     value['value'])
-

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -15,3 +15,4 @@ def test_player():
     assert float(player.killspermatch) == round(int(player.kills) / int(player.matchesplayed), 2)
     assert int(player.damage) >= 12638
     assert player.damagepermatch == round(player.damage / player.matchesplayed, 2)
+    assert len(player.sessions) > 1


### PR DESCRIPTION
Resolves #15 (from @xcodinas apex-legends repository)

This patch adds session data by making a 'second' request to the tracker sessions API, while creating the player object.

Added a small unit test just to confirm that sessions are indeed getting loaded and that there are more than one.